### PR TITLE
Corrected deploy.sh to handle target "nx" when making tarballs

### DIFF
--- a/avt_build/deploy.sh
+++ b/avt_build/deploy.sh
@@ -123,7 +123,7 @@ createDeployTarball()
 	cp "$FILE_INSTALL_SCRIPT" "$PATH_TARGET_DEPLOY_TMP_FOLDER"
 	cp "$FILE_KERNEL_IMAGE" "$PATH_TARGET_DEPLOY_TMP_FOLDER"
 
-	if [ "$DEDICATED_BOARD" = "$DEDICATED_BOARD_XAVIER" ]
+	if [ "$DEDICATED_BOARD" = "$DEDICATED_BOARD_XAVIER" ] || [ "$DEDICATED_BOARD" = "$DEDICATED_BOARD_NX" ]
 	then
 		#sed -i -e '/REQ_MACHINE=/c\REQ_MACHINE="NVidia Jetson AGX Xavier"' "$PATH_TARGET_DEPLOY_TMP_FOLDER/install.sh"
 		#cp "$FILE_DEVICE_TREE_BLOB_XAVIER" "$PATH_TARGET_DEPLOY_TMP_FOLDER"
@@ -132,7 +132,13 @@ createDeployTarball()
 			./l4t_generate_soc_bup.sh t19x
 		)
 		cp ${PATH_TARGET_L4T}/bootloader/payloads_t19x/bl_update_payload "$PATH_TARGET_DEPLOY_TMP_FOLDER"
-		sed -i -e '/REQ_MACHINE=/c\REQ_MACHINE="NVidia Jetson Xavier"' "$PATH_TARGET_DEPLOY_TMP_FOLDER/install.sh"
+
+		if [ "$DEDICATED_BOARD" = "$DEDICATED_BOARD_XAVIER" ]
+		then
+			sed -i -e '/REQ_MACHINE=/c\REQ_MACHINE="NVidia Jetson Xavier"' "$PATH_TARGET_DEPLOY_TMP_FOLDER/install.sh"
+		else
+			sed -i -e '/REQ_MACHINE=/c\REQ_MACHINE="NVidia Jetson NX"' "$PATH_TARGET_DEPLOY_TMP_FOLDER/install.sh"
+		fi
 
 	elif [ "$DEDICATED_BOARD" = "$DEDICATED_BOARD_TX2" ]
 	then
@@ -379,7 +385,7 @@ then
 		DEDICATED_BOARD="$DEDICATED_BOARD_NANO"
 		FLASH_BOARD_CONFIG="$FLASH_BOARD_CONFIG_NANO"
 		BOARD_SUB="2gb"
-	elif check_parameter $2 nx
+	elif check_parameter $2 "nx"
 	then
 		DEDICATED_BOARD="$DEDICATED_BOARD_NX"
 		FLASH_BOARD_CONFIG="$FLASH_BOARD_CONFIG_NX"


### PR DESCRIPTION
Two changes to deploy.sh so it works with the target "nx" when making tarballs

* Quote "nx" in the target selection if/else block  (not enough of a shell expert to know if this is meaningful, but can't hurt)
* Modified createDeployTarball() to use the same code block for either "xavier" or "nx"  targets.

I've tested that this script runs, and the the resulting tarball does update the kernel on my NX development kit, I do not have a "production" NX for test.