### PR TITLE
fix: root issues and subprocess erro

### DIFF
--- a/avt_build/jetson_build/deploy.py
+++ b/avt_build/jetson_build/deploy.py
@@ -277,7 +277,7 @@ def install_modules(args, board):
   t = tools.tools(args)
   env = { **os.environ, 'ARCH': 'arm64', 'CROSS_COMPILE': common.common_dir(args) / 'gcc/bin/aarch64-linux-gnu-', 'LANG': 'C' }
   kernel_build_dir=common.common_dir(args) / "kernel"
-  t.execute(['sudo', 'make', f'O={kernel_build_dir}', f'INSTALL_MOD_PATH={board.build_dir / "Linux_for_Tegra/kernel/avt/kernel/debian/out"}', 'modules_install'], cwd=build.kernel_source_dir(args), env=env)
+  t.execute(['make', f'O={kernel_build_dir}', f'INSTALL_MOD_PATH={board.build_dir / "Linux_for_Tegra/kernel/avt/kernel/debian/out"}', 'modules_install'], cwd=build.kernel_source_dir(args), env=env)
 
 
 def get_dtb_names(args, board):
@@ -287,7 +287,7 @@ def get_dtb_names(args, board):
 def copy_device_trees(args, board, subdir):
   logging.info(f"Copying device tree blobs");
   t = tools.tools(args)
-  t.execute(["sudo", "cp"] + get_dtb_names(args, board) + [board.build_dir / subdir])
+  t.execute(["cp"] + get_dtb_names(args, board) + [board.build_dir / subdir])
 
 def sign_device_trees(args,board,subdir):
   t = tools.tools(args)
@@ -298,7 +298,7 @@ def sign_device_trees(args,board,subdir):
 def copy_kernel_image(args, board):
   t = tools.tools(args)
   logging.info(f"Copying kernel image");
-  t.execute(["sudo", "cp", common.common_dir(args) / "kernel/arch/arm64/boot/Image", board.build_dir / "Linux_for_Tegra/kernel"])
+  t.execute(["cp", common.common_dir(args) / "kernel/arch/arm64/boot/Image", board.build_dir / "Linux_for_Tegra/kernel"])
 
 
 def copy_files_to_l4t(args, board):

--- a/avt_build/jetson_build/prepare.py
+++ b/avt_build/jetson_build/prepare.py
@@ -13,7 +13,7 @@ def prepare(args, board):
   t = tools.tools(args)
   logging.info(f"Preparing {board.name} in {board.build_dir}")
   logging.info("Extracting driver package")
-  t.extract(board.files.driver_package, board.build_dir, sudo=True)
+  t.extract(board.files.driver_package, board.build_dir)
   #logging.info("Extracting rootfs")
   #t.extract(board.files.rootfs, board.build_dir / 'Linux_for_Tegra/rootfs', sudo=True)
   logging.warning("Extracting public_sources DISABLED")

--- a/avt_build/jetson_build/tools.py
+++ b/avt_build/jetson_build/tools.py
@@ -50,7 +50,7 @@ def tools(args):
 
       outfile = kwargs.get('outfile', subprocess.PIPE)
 
-      sub = subprocess.Popen(args, bufsize=1, stdout=outfile, stderr=subprocess.PIPE, cwd=kwargs.get('cwd', None), env=kwargs.get('env', None))
+      sub = subprocess.Popen(args, stdout=outfile, stderr=subprocess.PIPE, cwd=kwargs.get('cwd', None), env=kwargs.get('env', None))
 
       logging.verbose(f"Executing `{' '.join(str(x) for x in args)}`")
 


### PR DESCRIPTION
fixed: execution of commands that previously required root access - also fixes output so no root is required to move files
fixed: subprocess popen would fail because of output size -  fixed bufsize warning 

this may also apply to downstream branchs